### PR TITLE
Add cloud type flipcard game

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,8 @@ python app.py
 ```
 
 Abre `http://localhost:5000` en tu navegador para usar el chatbot.
+
+## Cloud Types Flipcard Game
+
+Open `index.html` in your browser to play an English flashcard game about cloud types.
+It features 27 cards and a scoreboard for three teams with +20, -10, and 0 point options.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Cloud Types Flipcard Game</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <header>
+    <h1>Cloud Types Flipcard Game</h1>
+    <div id="scoreboard">
+      <div class="team" data-team="0">
+        <h2>Team 1: <span class="score">0</span></h2>
+        <div class="buttons">
+          <button class="score-btn" data-team="0" data-points="20">+20</button>
+          <button class="score-btn" data-team="0" data-points="-10">-10</button>
+          <button class="score-btn" data-team="0" data-points="0">0</button>
+        </div>
+      </div>
+      <div class="team" data-team="1">
+        <h2>Team 2: <span class="score">0</span></h2>
+        <div class="buttons">
+          <button class="score-btn" data-team="1" data-points="20">+20</button>
+          <button class="score-btn" data-team="1" data-points="-10">-10</button>
+          <button class="score-btn" data-team="1" data-points="0">0</button>
+        </div>
+      </div>
+      <div class="team" data-team="2">
+        <h2>Team 3: <span class="score">0</span></h2>
+        <div class="buttons">
+          <button class="score-btn" data-team="2" data-points="20">+20</button>
+          <button class="score-btn" data-team="2" data-points="-10">-10</button>
+          <button class="score-btn" data-team="2" data-points="0">0</button>
+        </div>
+      </div>
+    </div>
+  </header>
+
+  <main>
+    <div id="card-container">
+      <div id="card" class="card">
+        <div class="front"></div>
+        <div class="back"></div>
+      </div>
+    </div>
+    <div class="controls">
+      <button id="flip-btn">Flip</button>
+      <button id="next-btn">Next Card</button>
+    </div>
+  </main>
+
+  <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,77 @@
+const cards = [
+  { front: 'Cirrus fibratus', back: 'Thin, fibrous streaks high in the sky.' },
+  { front: 'Cirrus uncinus', back: 'Tufted cirrus with hooks or comma shapes.' },
+  { front: 'Cirrus spissatus', back: 'Dense cirrus forming patches or layers.' },
+  { front: 'Cirrostratus fibratus', back: 'Thin fibrous sheet that may show halos.' },
+  { front: 'Cirrostratus nebulosus', back: 'Uniform high-level veil producing halos.' },
+  { front: 'Cirrocumulus stratiformis', back: 'Small rippled rows of high clouds.' },
+  { front: 'Cirrocumulus lenticularis', back: 'Lens-shaped high-level clouds.' },
+  { front: 'Altostratus translucidus', back: 'Mid-level gray sheet letting the sun shine through.' },
+  { front: 'Altostratus opacus', back: 'Dense mid-level layer hiding the sun.' },
+  { front: 'Altocumulus floccus', back: 'Tufted mid-level masses with trailing bases.' },
+  { front: 'Altocumulus lenticularis', back: 'Lens-shaped clouds in the mid levels.' },
+  { front: 'Nimbostratus', back: 'Thick, dark, rain-bearing layer.' },
+  { front: 'Stratocumulus stratiformis', back: 'Low, layered rolls covering the sky.' },
+  { front: 'Stratocumulus cumulogenitus', back: 'Stratocumulus formed from spreading cumulus.' },
+  { front: 'Stratus nebulosus', back: 'Low uniform layer resembling fog.' },
+  { front: 'Stratus fractus', back: 'Ragged shreds beneath other clouds.' },
+  { front: 'Cumulus humilis', back: 'Small fair-weather heaps.' },
+  { front: 'Cumulus mediocris', back: 'Moderate heaps with rounded tops.' },
+  { front: 'Cumulus congestus', back: 'Towering heaps with cauliflower tops.' },
+  { front: 'Towering Cumulus', back: 'Large cumulus with strong vertical growth.' },
+  { front: 'Cumulonimbus calvus', back: 'Thundercloud with a smooth top.' },
+  { front: 'Cumulonimbus capillatus', back: 'Thundercloud with a fibrous top.' },
+  { front: 'Cumulonimbus incus', back: 'Anvil-shaped thundercloud.' },
+  { front: 'Cirrus aviaticus', back: 'Line-shaped cloud formed by aircraft.' },
+  { front: 'Kelvin-Helmholtz wave', back: 'Clouds shaped like breaking waves due to wind shear.' },
+  { front: 'Mammatus', back: 'Pouch-like projections hanging beneath a cloud.' },
+  { front: 'Fog', back: 'Stratus cloud at ground level.' }
+];
+
+let current = 0;
+const card = document.getElementById('card');
+const front = card.querySelector('.front');
+const back = card.querySelector('.back');
+
+function showCard(index) {
+  const data = cards[index];
+  front.textContent = data.front;
+  back.textContent = data.back;
+  card.classList.remove('flipped');
+}
+
+function nextCard() {
+  if (current < cards.length - 1) {
+    current++;
+    showCard(current);
+  } else {
+    front.textContent = 'End of deck';
+    back.textContent = '';
+    card.classList.remove('flipped');
+  }
+}
+
+showCard(current);
+
+document.getElementById('flip-btn').addEventListener('click', () => {
+  card.classList.toggle('flipped');
+});
+
+document.getElementById('next-btn').addEventListener('click', nextCard);
+
+const scores = [0, 0, 0];
+
+function updateScore(team, points) {
+  scores[team] += points;
+  const teamDiv = document.querySelector(`.team[data-team="${team}"]`);
+  teamDiv.querySelector('.score').textContent = scores[team];
+}
+
+const buttons = document.querySelectorAll('.score-btn');
+buttons.forEach(btn => {
+  btn.addEventListener('click', () => {
+    const team = parseInt(btn.getAttribute('data-team'), 10);
+    const points = parseInt(btn.getAttribute('data-points'), 10);
+    updateScore(team, points);
+  });
+});

--- a/style.css
+++ b/style.css
@@ -1,0 +1,94 @@
+body {
+  font-family: Arial, sans-serif;
+  background: linear-gradient(to bottom, #87ceeb, #f0f8ff);
+  margin: 0;
+  text-align: center;
+}
+
+header {
+  background-color: #4a90e2;
+  color: white;
+  padding: 1rem;
+}
+
+#scoreboard {
+  display: flex;
+  justify-content: center;
+  gap: 2rem;
+  flex-wrap: wrap;
+}
+
+.team {
+  background: #fff;
+  border-radius: 8px;
+  padding: 0.5rem 1rem;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.2);
+}
+
+.buttons {
+  margin-top: 0.5rem;
+  display: flex;
+  gap: 0.5rem;
+  justify-content: center;
+}
+
+button {
+  cursor: pointer;
+  padding: 0.5rem 1rem;
+  border: none;
+  border-radius: 4px;
+  background-color: #4a90e2;
+  color: white;
+  font-size: 1rem;
+}
+
+button:hover {
+  background-color: #357ab8;
+}
+
+#card-container {
+  perspective: 1000px;
+  margin: 2rem auto;
+  width: 300px;
+  height: 200px;
+}
+
+.card {
+  width: 100%;
+  height: 100%;
+  position: relative;
+  transform-style: preserve-3d;
+  transition: transform 0.6s;
+  cursor: pointer;
+}
+
+.card.flipped {
+  transform: rotateY(180deg);
+}
+
+.card .front,
+.card .back {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  backface-visibility: hidden;
+  border-radius: 8px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.2rem;
+  padding: 1rem;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.2);
+  background-color: #fff;
+}
+
+.card .back {
+  transform: rotateY(180deg);
+}
+
+.controls {
+  margin-top: 1rem;
+  display: flex;
+  gap: 1rem;
+  justify-content: center;
+}


### PR DESCRIPTION
## Summary
- Add a standalone flipcard game with 27 English cloud-type cards
- Include three-team scoreboard with +20, -10, and 0 point buttons
- Document how to use the new game in README

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest` *(no tests ran)*

------
https://chatgpt.com/codex/tasks/task_e_688f7ff2e94c83228d0e57a1f3f5f1b1